### PR TITLE
Pass $halt to Illuminate\Events\Dispatcher::fire() method

### DIFF
--- a/src/Authority/Events/Dispatcher.php
+++ b/src/Authority/Events/Dispatcher.php
@@ -21,7 +21,7 @@ class Dispatcher extends IlluminateDispatcher
             $payload = new Event($payload);
         }
 
-        return parent::fire($eventName, array($payload));
+        return parent::fire($eventName, array($payload), $halt);
     }
 
 }


### PR DESCRIPTION
The halt variable is declared in the method signature but it's never passed to Illuminate\Events\Dispatcher::fire()
