### PR TITLE
Last Rule Now Trumps Previous Rules

### DIFF
--- a/src/Authority/Authority.php
+++ b/src/Authority/Authority.php
@@ -83,10 +83,14 @@ class Authority
             $allowed = array_reduce($rules->all(), function($result, $rule) use ($self, $resourceValue) {
                 return $result && $rule->isAllowed($self, $resourceValue);
             }, true);
+
+            $myRules = $rules->all();
+            $last = end($myRules);
+
+            $allowed = $allowed || $last->isAllowed($self, $resourceValue);
         } else {
             $allowed = false;
         }
-
         return $allowed;
     }
 
@@ -247,7 +251,7 @@ class Authority
     {
         return $this->currentUser;
     }
-    
+
     /**
      * Returns current user - alias of getCurrentUser()
      *

--- a/tests/AuthorityTest.php
+++ b/tests/AuthorityTest.php
@@ -106,4 +106,17 @@ class AuthorityTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->auth->can('comment', $user2));
         $this->assertFalse($this->auth->can('comment', 'User', $user2));
     }
+
+    public function testLastRuleOverridesPreviousRules()
+    {
+        $user = $this->user;
+
+        $this->auth->allow('comment', 'User', function ($self, $a_user) {
+            return $self->getCurrentUser()->id != $a_user->id;
+        });
+
+        $this->auth->allow('comment', 'User');
+
+        $this->assertFalse($this->auth->can('comment', $user));
+    }
 }


### PR DESCRIPTION
I was using Authority and found that the last rule was sometimes not fired and was not trumping previous rules. This as a simple commit with an added test and some code to make this work as expected. 

Thanks for Authority, it's great!
