### PR TITLE
Prep for 2.1.0 release - works nicely with Laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "2.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Merge in this PR, then release a new tag for version 2.1.0.  Combined with the PR in machuga/authority-l4, it should make installing things easier for L4.1 users.
