### PR TITLE
Testing Updates And Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
 
 before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar install --dev
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-source --dev
 
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,12 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/events": "~4"
+        "illuminate/events": "~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
-        "mockery/mockery": "0.7.*"
+        "phpunit/phpunit": "~4.0",
+        "mockery/mockery": "~0.9.1"
     },
-    "minimum-stability": "stable",
     "autoload": {
         "psr-0": {
             "Authority": "src/"

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -7,7 +7,8 @@ class RuleTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->rule = new Rule(true, 'read', m::mock('Obj'));
+        $this->mock = m::mock('Obj');
+        $this->rule = new Rule(true, 'read', $this->mock);
     }
 
     public function tearDown()
@@ -35,15 +36,14 @@ class RuleTest extends PHPUnit_Framework_TestCase
     public function testCanMatchResource()
     {
         $this->assertTrue($this->rule->matchesResource(m::mock('Obj')));
-        $this->assertTrue($this->rule->matchesResource('Mockery\\Mock'));
         $this->assertFalse($this->rule->matchesResource('Duck'));
     }
 
     public function testCanDetermineRelevance()
     {
-        $this->assertTrue($this->rule->isRelevant('read', 'Mockery\\Mock'));
-        $this->assertTrue($this->rule->isRelevant(array('read', 'write'), 'Mockery\\Mock'));
-        $this->assertFalse($this->rule->isRelevant('write', 'Mockery\\Mock'));
+        $this->assertTrue($this->rule->isRelevant('read', $this->mock));
+        $this->assertTrue($this->rule->isRelevant(array('read', 'write'), $this->mock));
+        $this->assertFalse($this->rule->isRelevant('write', $this->mock));
     }
 
     public function testCanSetAndCheckIfAllowed()


### PR DESCRIPTION
Your `~4` version constraint is wrong. It implies it would be compatible with laravel 5, or 6 too, which it wouldn't. I've also updated your dev dependencies and updated the tests for that.
